### PR TITLE
适应4.19.4新版本astrbot关于绘画绑定服务端返回的data为none的bug修复

### DIFF
--- a/desktop_client/api_client.py
+++ b/desktop_client/api_client.py
@@ -1665,9 +1665,17 @@ class AstrBotApiClient:
                             event_data = json.loads(data_str)
                             event_type = event_data.get("type", "plain")
 
+                            raw_data = event_data.get("data")
+                            if raw_data is None:
+                                data_value = ""
+                            elif not isinstance(raw_data,str):
+                                data_value = str(raw_data)
+                            else:
+                                data_value = raw_data
+
                             event = SSEEvent(
                                 event_type=event_type,
-                                data=event_data.get("data", ""),
+                                data=data_value,
                                 streaming=event_data.get("streaming", False),
                                 chain_type=event_data.get("chain_type", "normal"),
                                 raw=event_data,


### PR DESCRIPTION
 4.19.4新版本bot优化了一下SSE的会话绑定逻辑,从老版本的bot服务端是等待ai响应后再把会话消息绑定,到新版本是回复没开始前就建立的绑定,导致新版本会话绑定时result是空的,数据返回时客户端检测到data内容为空而不是空字符串,无法调用len检查长度,导致直接抛异常,并且客户端主动断开了链接.本请求新增的data的none判断,为none则赋值为空字符串来解决bug